### PR TITLE
Add new endpoint for returning last record timestamp

### DIFF
--- a/app/controllers/datas_controller.rb
+++ b/app/controllers/datas_controller.rb
@@ -50,7 +50,8 @@ class DatasController < ApplicationController
   end
 
   def get_last_record_date
-    timestamp = DataRecord.where(device_id: params[:device_id]).order("timestamp").select(:id, :timestamp).last
+    return unless sensor_id = get_sensor_id(params[:data_type])
+    timestamp = DataRecord.where(device_id: params[:device_id], sensor_id: sensor_id).order("timestamp").select(:id, :timestamp).last
     check_record_blank(
       timestamp,
       'Timestamp of the last record for requested device',

--- a/app/controllers/datas_controller.rb
+++ b/app/controllers/datas_controller.rb
@@ -49,6 +49,15 @@ class DatasController < ApplicationController
     )
   end
 
+  def get_last_record_date
+    timestamp = DataRecord.where(device_id: params[:device_id]).order("timestamp").select(:id, :timestamp).last
+    check_record_blank(
+      timestamp,
+      'Timestamp of the last record for requested device',
+      'No records found for requested device'
+    )
+  end
+
   def create
     logger.info params
     return unless sensor_id = get_sensor_id(params[:data_type])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
   # Data records management
   get 'records' => 'datas#index'
   get 'records/:device_id' => 'datas#show'
-  get 'records/last/:device_id' => 'datas#get_last_record_date'
   get 'records/:device_id/:data_type' => 'datas#show_type'
+  get 'records/:device_id/:data_type/last' => 'datas#get_last_record_date'
   get 'records/:device_id/:data_type/:date' => 'datas#show_date'
   get 'records/:device_id/:data_type/:start_date/:end_date' => "datas#show_range"
   post 'records/:data_type' => 'datas#create'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   # Data records management
   get 'records' => 'datas#index'
   get 'records/:device_id' => 'datas#show'
+  get 'records/last/:device_id' => 'datas#get_last_record_date'
   get 'records/:device_id/:data_type' => 'datas#show_type'
   get 'records/:device_id/:data_type/:date' => 'datas#show_date'
   get 'records/:device_id/:data_type/:start_date/:end_date' => "datas#show_range"

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -208,7 +208,7 @@
         null,
         null,
         null,
-        295,
+        300,
         null,
         null,
         null,
@@ -402,6 +402,7 @@
         null,
         null,
         1,
+        2,
         1,
         1,
         null,
@@ -432,12 +433,12 @@
         1,
         null,
         1,
-        12,
-        12,
-        10,
+        14,
+        14,
+        11,
         null,
-        2,
-        2,
+        3,
+        3,
         null,
         null,
         null,
@@ -625,6 +626,6 @@
         null
       ]
     },
-    "timestamp": 1541609078
+    "timestamp": 1541609793
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -208,7 +208,7 @@
         null,
         null,
         null,
-        290,
+        295,
         null,
         null,
         null,
@@ -271,6 +271,7 @@
         null,
         null,
         null,
+        1,
         1,
         1,
         1,
@@ -401,6 +402,15 @@
         null,
         null,
         1,
+        1,
+        1,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        1,
         5,
         5,
         4,
@@ -440,8 +450,8 @@
         null,
         null,
         1,
-        8,
-        4,
+        9,
+        5,
         null,
         4,
         null,
@@ -615,6 +625,6 @@
         null
       ]
     },
-    "timestamp": 1541409638
+    "timestamp": 1541609078
   }
 }

--- a/spec/requests/datas_spec.rb
+++ b/spec/requests/datas_spec.rb
@@ -103,6 +103,13 @@ RSpec.describe 'Data records management' do
             expect(json['status']).to eql('ERROR')
             expect(response.status).to eql(404)
         end
+
+        it 'supports getting a "/last" endpoint plus a device_id to return the timestamp of the last record' do
+            get '/records/last/ABC000111/', :headers => { Authorization: "Bearer #{@token}" }
+            json = JSON.parse response.body
+            expect(json['status']).to eql('SUCCESS')
+            expect(response.status).to eql(200)
+        end
     end
 
     describe 'POST /records/:data_type' do

--- a/spec/requests/datas_spec.rb
+++ b/spec/requests/datas_spec.rb
@@ -105,10 +105,17 @@ RSpec.describe 'Data records management' do
         end
 
         it 'supports getting a "/last" endpoint plus a device_id to return the timestamp of the last record' do
-            get '/records/last/ABC000111/', :headers => { Authorization: "Bearer #{@token}" }
+            get '/records/ABC000111/temperature/last', :headers => { Authorization: "Bearer #{@token}" }
             json = JSON.parse response.body
             expect(json['status']).to eql('SUCCESS')
             expect(response.status).to eql(200)
+        end
+
+        it 'return a status message (ERROR) if there is no record for the device and/or type requested' do
+            get '/records/ABC696969/type_inconnu/last', :headers => { Authorization: "Bearer #{@token}" }
+            json = JSON.parse response.body
+            expect(json['status']).to eql('ERROR')
+            expect(response.status).to eql(404)
         end
     end
 


### PR DESCRIPTION
Resolves #21 

Add a new endpoint: 
```
/records/:device_id/:data_type/last 
```
which returns the timestamp for the last data record for a specific device and sensor